### PR TITLE
Add support for automatic Aaper initialisation using AndroidX Startup library

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,6 @@ runtime permission requests.
 
 ### Default behavior example
 
-```kotlin  
-// Aaper initialization  
-package my.app
-
-class MyApplication {  
-  
-    override fun onCreate() {  
-        super.onCreate()  
-        Aaper.init()// This must be called only once, therefore the Application.onCreate method is a great place to do so.
-    }  
-}  
-```  
-
 ```xml
 <!--Your AndroidManifest.xml-->
 
@@ -235,7 +222,6 @@ class MyApp : Application() {
   
     override fun onCreate() {  
         super.onCreate()  
-        Aaper.init()  
         val strategyProvider = Aaper.getRequestStrategyProvider() as DefaultRequestStrategyProvider  
         strategyProvider.register(FinishActivityOnDeniedStrategy())  
     }  
@@ -435,8 +421,24 @@ on the class and its methods: https://javadoc.io/doc/com.likethesalad.android/aa
 
 #### Using your custom RequestStrategyProvider
 
-After you've created your own `RequestStrategyProvider`, you can set it into Aaper's initialization
-method like so:
+After you've created your own `RequestStrategyProvider`, you need to disable the Aaper's automatic
+initialization in your `AndroidManifest.xml` file
+
+```xml
+<application>
+    <provider
+        android:name="androidx.startup.InitializationProvider"
+        android:authorities="${applicationId}.androidx-startup"
+        android:exported="false"
+        tools:node="merge">
+        <meta-data android:name="com.likethesalad.android.aaper.AaperInitializer"
+            tools:node="remove" />
+    </provider>
+</application>
+```
+
+Once you disabled the automatic initialization, you can manually call `Aaper.init` to pass your
+custom `RequestStrategy`.
 
 ```kotlin  
 class MyApp : Application() {  

--- a/aaper/build.gradle
+++ b/aaper/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     api project(":aaper-api")
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.core:core-ktx:1.3.1'
+    api "androidx.startup:startup-runtime:1.1.1"
     implementation "androidx.fragment:fragment-ktx:$fragment_version"
     testImplementation "com.likethesalad.tools.testing:unit-testing:$testingUtilities_version"
     testImplementation "org.robolectric:robolectric:$robolectric_version"

--- a/aaper/src/main/AndroidManifest.xml
+++ b/aaper/src/main/AndroidManifest.xml
@@ -1,2 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.likethesalad.android.aaper" />
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.likethesalad.android.aaper">
+
+    <application>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="com.likethesalad.android.aaper.AaperInitializer"
+                android:value="androidx.startup" />
+        </provider>
+    </application>
+</manifest>

--- a/aaper/src/main/java/com/likethesalad/android/aaper/AaperInitializer.kt
+++ b/aaper/src/main/java/com/likethesalad/android/aaper/AaperInitializer.kt
@@ -1,0 +1,15 @@
+package com.likethesalad.android.aaper
+
+import android.content.Context
+import androidx.startup.Initializer
+
+class AaperInitializer : Initializer<Unit> {
+
+  override fun create(context: Context) {
+    Aaper.init()
+  }
+
+  override fun dependencies(): List<Class<out Initializer<*>>> {
+    return emptyList()
+  }
+}


### PR DESCRIPTION
This provides support for automatically initializing Aaper library with default request strategy when the library is added as a dependency. Removes the step to add `Aaper.init` in the application class when using the default strategy. 

_Note: I have tested this by directly adding the `aaper` project as a dependency in the sample app module. I couldn't figure out how to test it with the plugin directly. As such I didn't remove the `Aaper.init` from the `MyApp` yet, if you can give me some guidance on it, I can make that change as well. I tried using the `publishMavenToLocal` task but it was show some signing errors._